### PR TITLE
Fix/svg secure parse

### DIFF
--- a/.changeset/fluffy-keys-scream.md
+++ b/.changeset/fluffy-keys-scream.md
@@ -2,4 +2,8 @@
 "@m2d/image": patch
 ---
 
-♻️ Use `@svg-fns/io`'s `parseSvg` to safely generate `<svg>`
+♻️ Use `@svg-fns/io`'s `parseSvg` to safely generate `<svg>` elements before attaching to the DOM.
+
+- Prevents unsafe string injection
+- Ensures valid, namespaced SVG elements
+- Improves consistency across different environments

--- a/.changeset/fluffy-keys-scream.md
+++ b/.changeset/fluffy-keys-scream.md
@@ -1,0 +1,5 @@
+---
+"@m2d/image": patch
+---
+
+♻️ Use `@svg-fns/io`'s `parseSvg` to safely generate `<svg>`

--- a/lib/package.json
+++ b/lib/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@m2d/core": "^1.7.0",
+    "@svg-fns/io": "^1.0.0",
     "@svg-fns/svg2img": "^0.0.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
         version: 1.5.1(remark-math@6.0.0)
       next:
         specifier: ^15.5.4
-        version: 15.5.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.93.2)
+        version: 15.5.4(@babel/core@7.28.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.93.2)
       nextjs-darkmode-lite:
         specifier: ^1.0.10
         version: 1.0.10(@types/react@19.1.13)(r18gs@3.0.1(@types/react@19.1.13)(react@19.1.1))(react@19.1.1)
@@ -187,6 +187,9 @@ importers:
       '@m2d/core':
         specifier: ^1.7.0
         version: 1.7.0(docx@9.5.1)
+      '@svg-fns/io':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@svg-fns/svg2img':
         specifier: ^0.0.0
         version: 0.0.0(sharp@0.34.4)
@@ -267,7 +270,7 @@ importers:
         version: 1.0.0(@types/react@19.1.13)(react@19.1.1)
       '@mayank1513/fork-me':
         specifier: ^2.1.3
-        version: 2.1.3(@types/react@19.1.13)(next@15.5.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.93.2))(react@19.1.1)
+        version: 2.1.3(@types/react@19.1.13)(next@15.5.4(@babel/core@7.28.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.93.2))(react@19.1.1)
       '@repo/scripts':
         specifier: workspace:*
         version: link:../../scripts
@@ -1319,6 +1322,14 @@ packages:
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
+
+  '@svg-fns/io@1.0.0':
+    resolution: {integrity: sha512-fDZTyIjbl327M9H8W6U1TJkaLlVNvSQ1SWLKjHTZlCWTywXQHJOIekpSHhCjlVc6ogU8uQ0E1/6UbPx60qv/NA==}
+    peerDependencies:
+      '@xmldom/xmldom': ^0.8.11
+    peerDependenciesMeta:
+      '@xmldom/xmldom':
+        optional: true
 
   '@svg-fns/svg2img@0.0.0':
     resolution: {integrity: sha512-9hj1BlZGabIhd8l93qge6rA+B0xb0+EDGWVA/1mHQ93Y+85aX4XQkuEptCqKogI0/BNW0Rzcedjw7idRknyy1w==}
@@ -4723,12 +4734,12 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mayank1513/fork-me@2.1.3(@types/react@19.1.13)(next@15.5.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.93.2))(react@19.1.1)':
+  '@mayank1513/fork-me@2.1.3(@types/react@19.1.13)(next@15.5.4(@babel/core@7.28.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.93.2))(react@19.1.1)':
     dependencies:
       '@types/react': 19.1.13
       react: 19.1.1
     optionalDependencies:
-      next: 15.5.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.93.2)
+      next: 15.5.4(@babel/core@7.28.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.93.2)
 
   '@mermaid-js/parser@0.6.2':
     dependencies:
@@ -4929,6 +4940,8 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@sindresorhus/merge-streams@2.3.0': {}
+
+  '@svg-fns/io@1.0.0': {}
 
   '@svg-fns/svg2img@0.0.0(sharp@0.34.4)':
     optionalDependencies:
@@ -6902,7 +6915,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@15.5.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.93.2):
+  next@15.5.4(@babel/core@7.28.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.93.2):
     dependencies:
       '@next/env': 15.5.4
       '@swc/helpers': 0.5.15
@@ -6910,7 +6923,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
-      styled-jsx: 5.1.6(react@19.1.1)
+      styled-jsx: 5.1.6(@babel/core@7.28.4)(react@19.1.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.4
       '@next/swc-darwin-x64': 15.5.4
@@ -6944,7 +6957,7 @@ snapshots:
       r18gs: 3.0.1(@types/react@19.1.13)(react@19.1.1)
       react: 19.1.1
     optionalDependencies:
-      next: 15.5.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.93.2)
+      next: 15.5.4(@babel/core@7.28.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.93.2)
 
   node-addon-api@7.1.1:
     optional: true
@@ -7549,10 +7562,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  styled-jsx@5.1.6(react@19.1.1):
+  styled-jsx@5.1.6(@babel/core@7.28.4)(react@19.1.1):
     dependencies:
       client-only: 0.0.1
       react: 19.1.1
+    optionalDependencies:
+      '@babel/core': 7.28.4
 
   stylis@4.3.6: {}
 


### PR DESCRIPTION
♻️ Use `@svg-fns/io`'s `parseSvg` to safely generate `<svg>` elements before attaching to the DOM.

- Prevents unsafe string injection
- Ensures valid, namespaced SVG elements
- Improves consistency across different environments